### PR TITLE
[GOV-4493] Update README, use new external unique ID, and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ yarn-error.log
 *bundle.js
 token_examples/raw/
 package-lock.json
+.vscode/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ You can learn more about [how Retool Embed works here.](https://docs.retool.com/
 
 ## 💻 Requirements
 
+### Retool custom domain
+If you are self-hosting Retool, you are already using a custom domain. [If you are using Retool Cloud, set up a custom domain by following these instructions](https://docs.retool.com/org-users/guides/cloud/custom-domains). Learn more about domain requirements related to embedding apps [here](https://docs.retool.com/apps/guides/app-management/embed-apps#use-the-same-domain).
+
+### Node
 This template requires Node.js version 16.14.2 or higher. Please make sure that you have Node.js installed before running the application. You can download Node.js from the official website: https://nodejs.org/
 
 If you have a different version of Node.js installed on your machine, you can use a version manager like [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to switch between different versions. 
@@ -31,13 +35,19 @@ $ `node -v`
 
 ## 🚀 Getting Started
 
+### Auth0 setup
+1. Create a new Auth0 Single Page Application using [Auth0's React guide](https://auth0.com/docs/quickstart/spa/react).
+2. This example expects users to have a `user_metadata` attribute called `group` containing the string of a single group such as `"gold"`. This is important to set up consistently with the values you provide in the following steps for `frontend/config.js` and `backend/retoolIdMaps.js`.
+
+### Repo setup
 1. Clone repo
 2. Setup the Frontend
     - Run `cp frontend/config-example.js frontend/config.js` 
-    - Update `frontend/config.js` with your Auth0 credentials (Domain and ClientID). See [this guide](https://auth0.com/docs/quickstart/spa/react#configure-auth0).
+    - Update `frontend/config.js` with your Auth0 credentials (Domain and ClientID). See [this guide](https://auth0.com/docs/quickstart/spa/react#configure-auth0). Update the sideBarList array (additional instructions can be found in the comments).
 3. Setup the Backend
     - Run `cp backend/.env.example backend/.env` 
     - Update `backend/.env` file to configure your RETOOL_API_KEY and RETOOL_URL.
+    - Update `backend/retoolIdMaps.js` with values according to the comments. No `0`'s should remain.
 4. Run `yarn install`
 5. Run `./start`
 6. Open `http:\\localhost:3001` in browser

--- a/README.md
+++ b/README.md
@@ -71,14 +71,13 @@ Mono-repo. Single project, but each of frontend and backend can be run separatel
 
 ```
 └── backend/
+    ├── retoolIdMaps.js        // defines mappings to converting Retool app names to UUIDs and IDP group metadata to Retool Group IDs
     ├── public/                // directory for serving static files
     │   └── index.html         // HTML file for the server's default page
-    ├── routes/                 // directory containing route handlers
-    │   ├── index.js            // entry point for the routes directory
-    │   ├── retool.js           // route handler for the /api/embedUrl endpoint. Makes a request to Retool to get the embed URL.
-    ├── utils/                 // directory for utility functions
-    │   └── retoolAppsToUuids.js // utility function for converting Retool app names to UUIDs
-    ├── server.js               // entry point for the server. Specifies the router files to use (index.js, retool.js)
+    ├── routes/                // directory containing route handlers
+    │   ├── index.js           // entry point for the routes directory
+    │   ├── retool.js          // route handler for the /api/embedUrl endpoint. Makes a request to Retool to get the embed URL.
+    ├── server.js              // entry point for the server. Specifies the router files to use (index.js, retool.js)
     ├── package.json           // file for managing dependencies
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Mono-repo. Single project, but each of frontend and backend can be run separatel
 
 ```
 └── backend/
-    ├── retoolIdMaps.js        // defines mappings to converting Retool app names to UUIDs and IDP group metadata to Retool Group IDs
+    ├── retoolIdMaps.js        // defines mappings to converting Retool app names to UUIDs and IDP user_metadata.group to Retool Group IDs
     ├── public/                // directory for serving static files
     │   └── index.html         // HTML file for the server's default page
     ├── routes/                // directory containing route handlers

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,8 @@
 # Env variables required by backend
 
 # The RETOOL_API_KEY is the token generated in this step https://docs.retool.com/docs/embed-retool-apps#1-generate-an-access-token
-
 export RETOOL_API_KEY=YOUR_RETOOL_API_KEY
+
+# The RETOOL_URL is the URL of your Retool instance not including the protocol (https://)
+# For example: retool.yourcompany.com or yourcompany.retool.com
 export RETOOL_URL=YOUR_RETOOL_URL

--- a/backend/retoolIdMaps.js
+++ b/backend/retoolIdMaps.js
@@ -1,4 +1,5 @@
 // Define mappings for frontend/config.js's  retoolAppName values to Retool app UUIDs
+// You can find the UUID of a Retool app by editing the app in Retool and copying the UUID from the URL
 const retoolAppMap = {
    storeManager: "966bf7fc-9057-11ed-bb00-b78554d89588",
    orderHistory: "56a70878-5e43-11ed-b603-5f3bd9271091",

--- a/backend/retoolIdMaps.js
+++ b/backend/retoolIdMaps.js
@@ -1,0 +1,19 @@
+const retoolAppMap = {
+   storeManager: "966bf7fc-9057-11ed-bb00-b78554d89588",
+   orderHistory: "56a70878-5e43-11ed-b603-5f3bd9271091",
+   couponGenerator: "69176596-4009-11ed-92e5-13ce361830e2",
+   customViews: "32ecf700-44ab-11ed-8cc2-eb54dae5f4e2"
+};
+
+// Define a fallback group in case the user's IDP group is not in the mapping
+const fallbackRetoolGroupId = 0 // Typically your "External Users" group in Retool
+
+// Map of Auth0 user_metadata.group to Retool group ID
+const idpGroupToRetoolGroupMap = {
+   external: 0,
+   bronze: 0,
+   silver: 0,
+   gold: 0,
+}
+
+module.exports = { retoolAppMap, fallbackRetoolGroupId, idpGroupToRetoolGroupMap };

--- a/backend/retoolIdMaps.js
+++ b/backend/retoolIdMaps.js
@@ -1,3 +1,4 @@
+// Define mappings for frontend/config.js's  retoolAppName values to Retool app UUIDs
 const retoolAppMap = {
    storeManager: "966bf7fc-9057-11ed-bb00-b78554d89588",
    orderHistory: "56a70878-5e43-11ed-b603-5f3bd9271091",
@@ -6,9 +7,11 @@ const retoolAppMap = {
 };
 
 // Define a fallback group in case the user's IDP group is not in the mapping
-const fallbackRetoolGroupId = 0 // Typically your "External Users" group in Retool
+// You can find group IDs from your Permissions settings page (/settings/permissions) and selecting the "..." menu
+const fallbackRetoolGroupId = 0 // Typically your "External Users" group in Retool. Do not leave as 0.
 
 // Map of Auth0 user_metadata.group to Retool group ID
+// You can leave idpGroupToRetoolGroupMap as an empty object if you don't want to use this feature, but do not leave values as 0
 const idpGroupToRetoolGroupMap = {
    external: 0,
    bronze: 0,

--- a/backend/utils/retoolAppsToUuids.js
+++ b/backend/utils/retoolAppsToUuids.js
@@ -1,8 +1,0 @@
-const retoolAppMap = {
-   storeManager: "966bf7fc-9057-11ed-bb00-b78554d89588",
-   orderHistory: "56a70878-5e43-11ed-b603-5f3bd9271091",
-   couponGenerator: "69176596-4009-11ed-92e5-13ce361830e2",
-   customViews: "32ecf700-44ab-11ed-8cc2-eb54dae5f4e2"
-};
-
-module.exports = retoolAppMap

--- a/frontend/config-example.js
+++ b/frontend/config-example.js
@@ -1,7 +1,6 @@
 exports.deployOnLocalhost = true;
 
 // To get your Auth0 Domain, and ClientID, see this guide https://auth0.com/docs/quickstart/spa/react#configure-auth0
-
 exports.auth = {
   tokenDuration: "1800s",
   REACT_APP_AUTH0_DOMAIN: "YOUR_AUTH0_DOMAIN",

--- a/frontend/config-example.js
+++ b/frontend/config-example.js
@@ -10,6 +10,10 @@ exports.auth = {
 };
 
 exports.homepage = {
+  // List of apps to show on the side bar navigation pane.
+  // Be sure to map each `retoolAppName` to the corresponding Retool app UUID in the backend/retoolIdMaps.js file.
+  // The `groups` array should match the Auth0 user_metadata.group values you have set up in Auth0.
+  // Users will only see apps when their group (string) is in the sideBarList item's groups array.
   sidebarList: [
     {
       title: "Store manager",

--- a/frontend/src/components/RetoolWrapper.js
+++ b/frontend/src/components/RetoolWrapper.js
@@ -25,6 +25,7 @@ const RetoolWrapper = ({
     .then(res => res.json())
     .then(data => { 
       if(data.embedUrl){
+        setRetoolEmbedError(false)
         setRetoolEmbedUrl(data.embedUrl)
       } else {
         console.error('An error occurred when requesting a Retool embed URL:', {data})

--- a/frontend/src/components/RetoolWrapper.js
+++ b/frontend/src/components/RetoolWrapper.js
@@ -12,6 +12,7 @@ const RetoolWrapper = ({
 }) => { 
 
   const [retoolEmbedUrl, setRetoolEmbedUrl] = useState('')
+  const [retoolEmbedError, setRetoolEmbedError] = useState(false)
 
   useEffect(() => {
     // make a POST request to the backend to get the embed URL
@@ -22,13 +23,32 @@ const RetoolWrapper = ({
     };
     fetch('/api/embedUrl', options)
     .then(res => res.json())
-    .then(data => { setRetoolEmbedUrl(data.embedUrl)})
+    .then(data => { 
+      if(data.embedUrl){
+        setRetoolEmbedUrl(data.embedUrl)
+      } else {
+        console.error('An error occurred when requesting a Retool embed URL:', {data})
+        setRetoolEmbedError(true)
+      }
+    })
   }, [retoolAppName])
   
-  // if embed URL is available, return the Container and Retool components
-  return retoolEmbedUrl && (
-    <Container maxWidth={false} disableGutters style={{ marginTop: 66, border:  showBorder ? '5px dashed #FFD4D2' : 'none', boxShadow: "none"}}>
-        <Retool url={retoolEmbedUrl} data={{darkMode, font: activeFont}} />
+  return (
+    <Container
+      maxWidth={false}
+      disableGutters
+      style={{
+        marginTop: 66,
+        border: showBorder ? '5px dashed #FFD4D2' : 'none',
+        boxShadow: "none"
+      }}
+    >
+      {retoolEmbedError && (
+        <div style={{ color: 'red', padding: '1rem' }}>An error occurred while trying to retrieve your embed URL.</div>
+      )}
+      {retoolEmbedUrl && (
+        <Retool url={retoolEmbedUrl} data={{ darkMode, font: activeFont }} />
+      )}
     </Container>
   )
 }

--- a/frontend/src/components/RetoolWrapper.js
+++ b/frontend/src/components/RetoolWrapper.js
@@ -19,7 +19,7 @@ const RetoolWrapper = ({
     const options = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ retoolAppName, accessToken, userProfile })
+      body: JSON.stringify({ retoolAppName, accessToken })
     };
     fetch('/api/embedUrl', options)
     .then(res => res.json())


### PR DESCRIPTION
This PR makes a number of improvements, including:
- Updating the Retool Embed API call to pass `sub` (unique Auth0 user ID) instead of `azp` (OAuth client ID)
- Adding a mapping of IDP Group (`user_metadata.group` to Retool group IDs)
- Adds error handling in the UI when the Retool Embed API does not return an embed URL; logs error to JS console too
- Updates to the README, .env.example, and comments 